### PR TITLE
Bump org.spring-security-version from 4.0.3.RELEASE to 5.2.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<org.springframework-version>4.2.3.RELEASE</org.springframework-version>
-		<org.spring-security-version>4.0.3.RELEASE</org.spring-security-version>
+		<org.spring-security-version>5.2.0.RELEASE</org.spring-security-version>
 		<org.slf4j-version>1.7.13</org.slf4j-version>
 	</properties>
 


### PR DESCRIPTION
Bumps `org.spring-security-version` from 4.0.3.RELEASE to 5.2.0.RELEASE.

Updates `spring-security-core` from 4.0.3.RELEASE to 5.2.0.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.2.0.RELEASE)

Updates `spring-security-config` from 4.0.3.RELEASE to 5.2.0.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.2.0.RELEASE)

Updates `spring-security-web` from 4.0.3.RELEASE to 5.2.0.RELEASE
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Commits](https://github.com/spring-projects/spring-security/compare/4.0.3.RELEASE...5.2.0.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>